### PR TITLE
Fixes #41 Debug normals

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
       <a-entity id="leftHand" shoot-controls="hand: left" weapon shoot></a-entity>
       <a-entity id="rightHand" shoot-controls="hand: right" weapon shoot></a-entity>
 
-      <a-entity id="border" json-model="src:url(https://feiss.github.io/a-shooter-assets/models/border.json);" position="0 0 2"></a-entity>
+      <a-entity id="border" json-model="src:url(https://feiss.github.io/a-shooter-assets/models/border.json); debugNormals: true" position="0 0 2"></a-entity>
 
       <a-entity id="gamestateDebug"
         gamestate-debug

--- a/src/components/json-model.js
+++ b/src/components/json-model.js
@@ -2,12 +2,15 @@
 AFRAME.registerComponent('json-model', {
   schema: {
     src: {type: 'src'},
-    vertexcolors: {default: false}
+    vertexcolors: {default: false},
+    debugNormals: {default: false},
+    debugNormalsLength: {default: 0.2}
   },
 
   init: function () {
     this.objectLoader = new THREE.ObjectLoader();
     this.objectLoader.setCrossOrigin('');
+    this.helpers = new THREE.Group();
   },
 
   fixNormal: function (vector) {
@@ -22,6 +25,8 @@ AFRAME.registerComponent('json-model', {
     if (!src || src === oldData.src) { return; }
 
     this.objectLoader.load(this.data.src, function (group) {
+      self.helpers = new THREE.Group();
+
       // var Rotation = new THREE.Matrix4().makeRotationX(-Math.PI / 2);
       group.traverse(function (child) {
         if (!(child instanceof THREE.Mesh)) { return; }
@@ -39,10 +44,18 @@ AFRAME.registerComponent('json-model', {
 */
         child.geometry.normalsNeedUpdate = true;
         child.geometry.verticesNeedUpdate = true;
-        // child.material = new THREE.MeshPhongMaterial();
+
+        fnh = new THREE.FaceNormalsHelper(child, self.data.debugNormalsLength);
+        self.helpers.add(fnh);
+        vnh = new THREE.VertexNormalsHelper(child, self.data.debugNormalsLength);
+        self.helpers.add(vnh);
       });
+      self.el.setObject3D('helpers', self.helpers);
       self.el.setObject3D('mesh', group);
       self.el.emit('model-loaded', {format: 'json', model: group, src: src});
+      self.helpers.visible = self.data.debugNormals;
     });
+
+    this.helpers.visible = this.data.debugNormals;
   }
 });

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ require('./enemies/enemy3.js');
 require('./enemies/enemy_static.js');
 
 // Components
+require('./components/normals-helper.js');
 require('./components/decals.js');
 require('./components/collision-helper.js');
 require('./components/gamestate.js');


### PR DESCRIPTION
Added two parameters to `json-model` to show normals (Yellow: face normals, Red: vertex normals):
- `debugNormals`: true/false
- `debugNormalsLength`: default 0.3.

![image](https://cloud.githubusercontent.com/assets/782511/19629455/37554a36-9976-11e6-9ff4-e41711602851.png)

It's quite simple and not so customisable, but we could work on that if we need it later.

/cc @feiss 
