### PR TITLE
fixed normalfix

### DIFF
--- a/src/components/json-model.js
+++ b/src/components/json-model.js
@@ -41,10 +41,8 @@ AFRAME.registerComponent('json-model', {
       group.traverse(function (child) {
         if (!(child instanceof THREE.Mesh)) { return; }
 
-/*
         // child.position.applyMatrix4(Rotation);
         child.geometry.faces.forEach(face => {
-          self.fixNormal(face.normal);
           face.vertexNormals.forEach(vertex => {
             if (!vertex.hasOwnProperty('fixed')) {
               self.fixNormal(vertex);
@@ -52,7 +50,7 @@ AFRAME.registerComponent('json-model', {
             }
           });
         });
-*/
+
         child.geometry.normalsNeedUpdate = true;
         child.geometry.verticesNeedUpdate = true;
 


### PR DESCRIPTION
fixes #38 

the normal fix was necessary for vertex normals, but not for face normals:

previous behaviour:

![image](https://cloud.githubusercontent.com/assets/359872/20094746/eeb50e22-a5a2-11e6-92d8-764f0c51fe8d.png)

after this commit:
![image](https://cloud.githubusercontent.com/assets/359872/20094848/583f78c8-a5a3-11e6-9781-21bd07f0fc39.png)
