### PR TITLE
fixed player bullets overlapping with gun

### DIFF
--- a/assets/models/player-bullet.json
+++ b/assets/models/player-bullet.json
@@ -27,7 +27,7 @@
         "transparent": true,
         "depthFunc": 3,
         "depthTest": true,
-        "depthWrite": true,
+        "depthWrite": false,
         "skinning": false,
         "morphTargets": false
     }],

--- a/src/bullets/player.js
+++ b/src/bullets/player.js
@@ -48,7 +48,13 @@ ABLAST.registerBullet(
     tick: function (time, delta) {
       //stretch trail
       if (this.trail && this.trail.scale.y < 1) {
-        var trailScale = this.trail.scale.y + delta/50;
+        var trailScale;
+        if (this.trail.scale.y < 0.005) {
+          trailScale = this.trail.scale.y + 0.001;
+        }
+        else {
+          trailScale = this.trail.scale.y + delta/50;
+        }
         if (trailScale > 1) { trailScale = 1; }
         this.trail.scale.setY(trailScale);
       }


### PR DESCRIPTION
Delayed full stretching 4 frames, and set bullet material's `depthWrite` to false