### PR TITLE
Update A-frame version and add Oculus Go controller support to A-blast

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="A WebVR wave shooter game using A-Frame by Mozilla VR.">
     <meta name="theme-color" content="#3d4d55">
     <!--<script src="vendor/aframe-master.min.js"></script>-->
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
+    <script src="https://rawgit.com/aframevr/aframe/3e7a4b3/dist/aframe-master.min.js"></script>
     <script src="build/build.js"></script>
     <script src="vendor/aframe-bmfont-component.min.js"></script>
     <script src="assets/data/waves.js"></script>
@@ -83,7 +83,7 @@
       ></a-entity>
 
       <a-entity id="player"
-        camera="userHeight: 1.6"
+        camera
         wasd-controls
         look-controls
         restrict-position

--- a/package-lock.json
+++ b/package-lock.json
@@ -1886,14 +1886,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -1902,6 +1894,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3651,15 +3651,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3669,6 +3660,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/src/components/bullet.js
+++ b/src/components/bullet.js
@@ -181,7 +181,7 @@ AFRAME.registerComponent('bullet', {
         }
       } else {
         // @hack Any better way to get the head position ?
-        var head = this.el.sceneEl.camera.el.components['look-controls'].dolly.position;
+        var head = this.el.sceneEl.camera.el.components['look-controls'].position;
         if (newBulletPosition.distanceTo(head) < 0.10 + bulletRadius) {
           this.hitObject('player');
           return;

--- a/src/components/enemy.js
+++ b/src/components/enemy.js
@@ -128,7 +128,7 @@ AFRAME.registerComponent('enemy', {
     var data = this.data;
     var mesh = el.object3D;
     var gunPosition = mesh.localToWorld(this.gunGlow.position.clone());
-    var head = el.sceneEl.camera.el.components['look-controls'].dolly.position.clone();
+    var head = el.sceneEl.camera.el.components['look-controls'].position.clone();
     var direction = head.sub(mesh.position).normalize();
 
     this.lastShootTime = time;
@@ -197,7 +197,7 @@ AFRAME.registerComponent('enemy', {
         this.gunGlow.position.y += this.hipBone.position.y;
       }
       // Make the droid to look the headset
-      var head = this.el.sceneEl.camera.el.components['look-controls'].dolly.position.clone();
+      var head = this.el.sceneEl.camera.el.components['look-controls'].position.clone();
       this.el.object3D.lookAt(head);
 
       this.definition.tick.call(this, time, delta);

--- a/src/components/json-model.js
+++ b/src/components/json-model.js
@@ -153,8 +153,5 @@ AFRAME.registerComponent('json-model', {
     for (var i in this.mixers) {
       this.mixers[i].mixer.update( timeDelta / 1000 );
     }
-    if (this.skeletonHelper) {
-      this.skeletonHelper.update();
-    }
   }
 });

--- a/src/components/shoot-controls.js
+++ b/src/components/shoot-controls.js
@@ -64,6 +64,7 @@ AFRAME.registerComponent('shoot-controls', {
     if (data.hand === 'right') {
       el.setAttribute('daydream-controls', {hand: data.hand, model: false});
       el.setAttribute('gearvr-controls', {hand: data.hand, model: false});
+      el.setAttribute('oculus-go-controls', {hand: data.hand, model: false});
     }
   }
 });

--- a/src/components/weapon.js
+++ b/src/components/weapon.js
@@ -26,7 +26,9 @@ AFRAME.registerComponent('weapon', {
 
   updateWeapon: function () {
     console.log(this.controllerModel);
-    if (this.controllerModel === 'oculus-touch-controller') {
+    if (this.controllerModel === 'oculus-touch-controller' ||
+        this.controllerModel === 'oculus-go-controls' ||
+        this.controllerModel === 'gearvr-controls') {
       this.model.applyMatrix(new THREE.Matrix4().makeRotationAxis(new THREE.Vector3(1, 0, 0), 0.8));
       this.el.setAttribute('shoot', {direction: '0 -0.3 -1'});
     } else if (this.controllerModel === 'daydream-controls') {
@@ -44,6 +46,7 @@ AFRAME.registerComponent('weapon', {
     this.weapon = WEAPONS[ this.data.type ];
 
     el.setAttribute('json-model', {src: this.weapon.model.url});
+    el.setAttribute('visible', false);
 
     el.setAttribute('sound', {
       src: this.weapon.shootSound,
@@ -57,6 +60,7 @@ AFRAME.registerComponent('weapon', {
 
     el.addEventListener('controllerconnected', function (evt) {
       console.log(evt);
+      el.setAttribute('visible', true);
       self.controllerModel = evt.detail.name;
       if (self.model == null) {
         self.isGamepadConnected = true;


### PR DESCRIPTION
This change bumps up the version of A-Frame to one that includes Oculus Go support, and then includes the oculus-go-controls component so A-blast works in Oculus Go.

However, the version bump also had some undesirable effects, so this pull request should likely not be merged as-is.