### PR TITLE
fixed website crash error by highscores

### DIFF
--- a/src/components/highscores.js
+++ b/src/components/highscores.js
@@ -27,11 +27,13 @@ AFRAME.registerSystem('highscores', {
 
     var self = this;
     var ablastUI = document.getElementById('ablast-ui');
-    document.getElementById('save-score').addEventListener('click', function (event) {
-      ABLAST.currentScore.name = document.getElementById('player-name').value;
-      self.addNewScore(ABLAST.currentScore);
-      ablastUI.style.display = 'none';
-    });
+    window.onload = function() {
+      document.getElementById('save-score').addEventListener('click', function (event) {
+        ABLAST.currentScore.name = document.getElementById('player-name').value;
+        self.addNewScore(ABLAST.currentScore);
+        ablastUI.style.display = 'none';
+      });
+    }
 
     this.sceneEl.addEventListener('gamestate-changed', function (evt) {
       if ('state' in evt.detail.diff) {


### PR DESCRIPTION
**Error:** The official [A-Blast website](https://aframe.io/a-blast/) crashes on opening because of some null value error in `highscores.js` file as of now.
![image](https://user-images.githubusercontent.com/21677583/155858728-d3ed6480-7fb2-4fa4-931b-117b83d46b43.png)

**Cause:** The `document.getElementById('save-score')` was returning the null value which in turn crashed the code

**Solution:** I added a window.onload function to solve the error such that the dom request is made only after the window is loaded